### PR TITLE
Lazy load Rails::Credentials::Command

### DIFF
--- a/lib/rails/conflicted/credentials.rb
+++ b/lib/rails/conflicted/credentials.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "credentials/version"
-require_relative "../commands/conflicted_credentials/conflicted_credentials_command"
 
 module Rails
   module Conflicted


### PR DESCRIPTION
The `anyway_config` gem [assumes](https://github.com/palkan/anyway_config/blob/64f819d7db271d0d84669e95a6ad69a9f111ac33/lib/anyway/rails/loaders/credentials.rb#L12) that if `Rails::Credentials::Command` is loaded, we are actively editing credentials. But we eager load it when this gem is loaded, so `anyway_config` always thinks we're editing credentials and stops loading credentials.

Allowing `Rails::Credentials::Command` to load when we need it lets `anyway_config` work and doesn't seem to affect the functioning of this gem.